### PR TITLE
Fixing loading error on rbenv

### DIFF
--- a/lib/rubyipmi/freeipmi/connection.rb
+++ b/lib/rubyipmi/freeipmi/connection.rb
@@ -4,7 +4,7 @@ require 'rubyipmi/commands/basecommand'
 require 'rubyipmi/freeipmi/commands/basecommand'
 
 Dir[File.dirname(__FILE__) + '/commands/*.rb'].each do |file|
-  require "#{file.split(".rb").first}"
+  require file
 end
 module Rubyipmi
   module Freeipmi

--- a/lib/rubyipmi/ipmitool/connection.rb
+++ b/lib/rubyipmi/ipmitool/connection.rb
@@ -4,7 +4,7 @@ require 'rubyipmi/commands/basecommand'
 require 'rubyipmi/ipmitool/commands/basecommand'
 
 Dir[File.dirname(__FILE__) + '/commands/*.rb'].each do |file|
-  require "#{file.split(".rb").first}"
+  require file
 end
 
 module Rubyipmi


### PR DESCRIPTION
Hello,

when using rbenv (or when do you "rb" string within your path) the rubygem refused to load for obvious reasons:

```
[root@localhost smart-proxy]# ruby -rrubyipmi -e true
/root/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/rubyipmi-0.5.0/lib/rubyipmi/ipmitool/commands/bmc.rb
/root/
/root/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- /root/ (LoadError)
    from /root/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /root/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/rubyipmi-0.5.0/lib/rubyipmi/ipmitool/connection.rb:9:in `block in <top (required)>'
    from /root/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/rubyipmi-0.5.0/lib/rubyipmi/ipmitool/connection.rb:6:in `each'
    from /root/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/rubyipmi-0.5.0/lib/rubyipmi/ipmitool/connection.rb:6:in `<top (required)>'
    from /root/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /root/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /root/.rbenv/versions/1.9.3-p392/lib/ruby/gems/1.9.1/gems/rubyipmi-0.5.0/lib/rubyipmi.rb:1:in `<top (required)>'
    from /root/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/custom_require.rb:60:in `require'
    from /root/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/custom_require.rb:60:in `rescue in require'
    from /root/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/custom_require.rb:35:in `require'
```

I don't understand why do you split the string as Ruby 1.8-2.0 loads files with extensions fine. Thus sending the fix.

Take care!
