### PR TITLE
Support multiple driver-types and add flexible options hash

### DIFF
--- a/lib/rubyipmi/freeipmi/connection.rb
+++ b/lib/rubyipmi/freeipmi/connection.rb
@@ -14,7 +14,7 @@ module Rubyipmi
       attr_accessor :options
 
 
-      def initialize(user, pass, host,debug=false)
+      def initialize(user, pass, host, debug=false, opts)
         @options = Rubyipmi::ObservableHash.new
         raise("Must provide a host to connect to") unless host
         @options["hostname"] = host
@@ -22,7 +22,10 @@ module Rubyipmi
         # So they are not required
         @options["username"] = user if user
         @options["password"] = pass if pass
-        #@options["driver-type"] = 'LAN_2_0'
+        @options["driver-type"] = 'LAN'      if opts[:driver] == "lan15"
+        @options["driver-type"] = 'LAN_2_0'  if opts[:driver] == "lan20"
+        @options["driver-type"] = 'OPENIPMI' if opts[:driver] == "open"
+
         #getWorkArounds
       end
 

--- a/lib/rubyipmi/ipmitool/connection.rb
+++ b/lib/rubyipmi/ipmitool/connection.rb
@@ -16,7 +16,7 @@ module Rubyipmi
       attr_reader :debug
 
 
-      def initialize(user, pass, host,debug_value=false)
+      def initialize(user, pass, host, debug_value=false, opts)
         @debug = debug_value
         @options = Rubyipmi::ObservableHash.new
         raise("Must provide a host to connect to") unless host
@@ -27,7 +27,9 @@ module Rubyipmi
         @options["P"] = pass if pass
         # default to IPMI 2.0 communication, this means that older devices will not work
         # Those old servers should be recycled by now, as the 1.0, 1.5 spec came out in 2005ish and is 2013.
-        #@options["I"] = "lanplus"
+        @options["I"] = "lan"     if opts[:driver] == "lan15"
+        @options["I"] = "lanplus" if opts[:driver] == "lan20"
+        @options["I"] = "open"    if opts[:driver] == "open"
 
         #getWorkArounds
       end


### PR DESCRIPTION
This commit makes it possible to define the IPMI driver that should be used with the underlying tools (i.e lan 1.5 or lan 2.0)

It also adds an options hash that maintain backwards compatibility with the positional arguments, but also allows provider, debug, and driver to be provided via the hash as named arguments.
