### PR TITLE
fix ipmitool power.on precheck.

### DIFF
--- a/lib/rubyipmi/ipmitool/commands/power.rb
+++ b/lib/rubyipmi/ipmitool/commands/power.rb
@@ -16,10 +16,10 @@ module Rubyipmi::Ipmitool
 
     # Turn on the system
     def on
-      if off?
-        command("on")
+      if on?
+        return true
       else
-         return true
+        command("on")
       end
     end
 


### PR DESCRIPTION
fix below.
- When occured precheck(power.status) error(_), power.on return
  incorrect result value(i.e. true).
  (_) Auth mismatch, IP addr typo, etc.
