### PR TITLE
Fix rubocop Style/MethodName "Use snake_case for method names."

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,10 +55,13 @@ Style/AccessorMethodName:
   Exclude:
     - 'lib/rubyipmi/freeipmi/connection.rb'
     - 'lib/rubyipmi/ipmitool/connection.rb'
-Style/MethodName:
-  Enabled: false
 GuardClause:
   Enabled: false
+
+# Fixed by deprecation
+Style/MethodName:
+  Exclude:
+    - 'lib/rubyipmi/commands/mixins/power_mixin.rb'
 
 # Don't understand
 Style/FileName:

--- a/lib/rubyipmi/commands/mixins/power_mixin.rb
+++ b/lib/rubyipmi/commands/mixins/power_mixin.rb
@@ -1,0 +1,50 @@
+module Rubyipmi
+  module PowerMixin
+    # Turn the system on
+    def on
+      command("on")
+    end
+
+    # Turn the system off
+    def off
+      command("off")
+    end
+
+    # Perform a power reset on the system
+    def reset
+      command("reset")
+    end
+
+    # Power cycle the system
+    def cycle
+      off? ? on : command("cycle")
+    end
+
+    # Perform a soft shutdown, like briefly pushing the power button
+    def soft_shutdown
+      command("soft")
+    end
+
+    # Test to see if the power is on
+    def on?
+      status == "on"
+    end
+
+    # Test to see if the power is off
+    def off?
+      status == "off"
+    end
+
+    # DEPRECATED: Please use soft_shutdown instead.
+    def softShutdown
+      warn "[DEPRECATION] `softShutdown` is deprecated, please use `soft_shutdown` instead."
+      soft_shutdown
+    end
+
+    # DEPRECATED: Please use power_interrupt instead.
+    def powerInterrupt
+      warn "[DEPRECATION] `powerInterrupt` is deprecated, please use `power_interrupt` instead."
+      power_interrupt
+    end
+  end
+end

--- a/lib/rubyipmi/freeipmi/commands/chassisconfig.rb
+++ b/lib/rubyipmi/freeipmi/commands/chassisconfig.rb
@@ -32,7 +32,7 @@ module Rubyipmi::Freeipmi
     end
 
     def bootdevice(device, persistent)
-      setBootFlag("Boot_Device", device, persistent)
+      set_boot_flag("Boot_Device", device, persistent)
     end
 
     def bootdevices
@@ -77,7 +77,7 @@ module Rubyipmi::Freeipmi
 
     private
 
-    def setBootFlag(key, flag, _persistent)
+    def set_boot_flag(key, flag, _persistent)
       @options["key-pair"] = "\"Chassis_Boot_Flags:#{key}=#{flag}\""
       value = commit
       @options.delete_notify("key-pair")

--- a/lib/rubyipmi/freeipmi/commands/power.rb
+++ b/lib/rubyipmi/freeipmi/commands/power.rb
@@ -1,5 +1,9 @@
+require 'rubyipmi/commands/mixins/power_mixin'
+
 module Rubyipmi::Freeipmi
   class Power < Rubyipmi::Freeipmi::BaseCommand
+    include Rubyipmi::PowerMixin
+
     def initialize(opts = ObservableHash.new)
       super("ipmipower", opts)
     end
@@ -12,37 +16,7 @@ module Rubyipmi::Freeipmi
       @result
     end
 
-    # Turn on the system
-    def on
-      command("on")
-    end
-
-    # Turn off the system
-    def off
-      command("off")
-    end
-
-    # Power cycle the system
-    def cycle
-      # if the system is off turn it on
-      if off?
-        on
-      else
-        command("cycle")
-      end
-    end
-
-    # Perform a power reset on the system
-    def reset
-      command("reset")
-    end
-
-    # Perform a soft shutdown, like briefly pushing the power button
-    def softShutdown
-      command("soft")
-    end
-
-    def powerInterrupt
+    def power_interrupt
       command("pulse")
     end
 
@@ -50,16 +24,6 @@ module Rubyipmi::Freeipmi
     def status
       value = command("stat")
       @result.split(":").last.chomp.strip if value
-    end
-
-    # Test to see if the power is on
-    def on?
-      status == "on"
-    end
-
-    # Test to see if the power is off
-    def off?
-      status == "off"
     end
   end
 end

--- a/lib/rubyipmi/ipmitool/commands/power.rb
+++ b/lib/rubyipmi/ipmitool/commands/power.rb
@@ -1,5 +1,9 @@
+require 'rubyipmi/commands/mixins/power_mixin'
+
 module Rubyipmi::Ipmitool
   class Power < Rubyipmi::Ipmitool::BaseCommand
+    include Rubyipmi::PowerMixin
+
     def initialize(opts = ObservableHash.new)
       super("ipmitool", opts)
     end
@@ -12,45 +16,7 @@ module Rubyipmi::Ipmitool
       value
     end
 
-    # Turn on the system
-    def on
-      if on?
-        return true
-      else
-        command("on")
-      end
-    end
-
-    # Turn off the system
-    def off
-      if off?
-        return true
-      else
-        command("off")
-      end
-    end
-
-    # Power cycle the system
-    def cycle
-      # if the system is off turn it on
-      if off?
-        on
-      else
-        command("cycle")
-      end
-    end
-
-    # Perform a power reset on the system
-    def reset
-      command("reset")
-    end
-
-    # Perform a soft shutdown, like briefly pushing the power button
-    def softShutdown
-      command("soft")
-    end
-
-    def powerInterrupt
+    def power_interrupt
       command("diag")
     end
 
@@ -58,16 +24,6 @@ module Rubyipmi::Ipmitool
     def status
       value = command("status")
       @result.match(/(off|on)/).to_s if value
-    end
-
-    # Test to see if the power is on
-    def on?
-      status == "on"
-    end
-
-    # Test to see if the power is off
-    def off?
-      status == "off"
     end
   end
 end

--- a/lib/rubyipmi/ipmitool/errorcodes.rb
+++ b/lib/rubyipmi/ipmitool/errorcodes.rb
@@ -28,28 +28,6 @@ module Rubyipmi
         end
         raise "No Fix found" if fix.nil?
       end
-
-      def throwError
-        # Find out what kind of error is happening, parse results
-        # Check for authentication or connection issue
-
-        if @result =~ /timeout|timed\ out/
-          code = "ipmi call: #{@lastcall} timed out"
-          raise code
-        else
-          code = @result.split(":").last.chomp.strip unless @result.empty?
-        end
-        case code
-        when "invalid hostname"
-          raise code
-        when "password invalid"
-          raise code
-        when "username invalid"
-          raise code
-        else
-          raise :ipmierror, code
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
Rename private method
Add deprecation warnings for two public methods
Delete unused method
Update .rubocop.yml accordingly
Refactor duplicated chassis power command methods