### PR TITLE
Fix infinite loop when executing 'lan print' command

### DIFF
--- a/lib/rubyipmi/ipmitool/commands/lan.rb
+++ b/lib/rubyipmi/ipmitool/commands/lan.rb
@@ -30,7 +30,11 @@ module Rubyipmi::Ipmitool
           # wait for error to occur then retry using channel 1
           if retrycount < MAX_RETRY
             @channel = 1
+            retrycount = retrycount.next
             retry
+          else
+            # failed to fetch info, return cached info
+            @info
           end
         end
       else


### PR DESCRIPTION
The retrycount counter is currently not incremented, so in the situation
when this command fails, library enters infinite loop of executing this
command, which is bad.

This commit adds missing counter incrementation with the same style as
in basecommands and make it return current @info in case of a faliure,
so all methods accessing it will just get return nil.