### PR TITLE
Exclude hidden files from the gem

### DIFF
--- a/rubyipmi.gemspec
+++ b/rubyipmi.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     "README.md"
   ]
   s.files = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(/^(test|spec|features)/) || f.match(/^*.tar\.gz/)
+    f.match(/^(\.|test|spec|features)/) || f.match(/^*.tar\.gz/)
   end
   s.homepage = "https://github.com/logicminds/rubyipmi"
   s.licenses = ["LGPLv2.1"]


### PR DESCRIPTION
While updating the RPM I saw this:

    error: Installed (but unpackaged) file(s) found:
       /usr/share/gems/gems/rubyipmi-0.11.0/.document
       /usr/share/gems/gems/rubyipmi-0.11.0/.gitignore
       /usr/share/gems/gems/rubyipmi-0.11.0/.rspec
       /usr/share/gems/gems/rubyipmi-0.11.0/.rubocop.yml
       /usr/share/gems/gems/rubyipmi-0.11.0/.travis.yml

None of them should be included.